### PR TITLE
Add path to index.html

### DIFF
--- a/deployment/route.yaml
+++ b/deployment/route.yaml
@@ -4,6 +4,7 @@ metadata:
   name: kaffeehaus
 spec:
   #  host: kaffeehaus.openshift.example.com
+  path: /index.html
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge


### PR DESCRIPTION
This is a very minor tweak to add a path to `index.html` to the route spec.